### PR TITLE
fix: sort by numeric file name

### DIFF
--- a/src/components/FileSelector.tsx
+++ b/src/components/FileSelector.tsx
@@ -93,7 +93,12 @@ const FileSelector = ({
     }
 
     // Sort by name
-    temp.sort((a, b) => a.name.localeCompare(b.name));
+    temp.sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      })
+    );
 
     setFiles(temp);
     setSelected(temp[0]);


### PR DESCRIPTION
# Before:
![Snipaste_2023-08-31_23-09-03](https://github.com/fishaudio/text-labeler/assets/35302658/f1c93cec-1a26-41c2-a608-c2bc15a80fe3)
# After:
![Snipaste_2023-08-31_23-10-56](https://github.com/fishaudio/text-labeler/assets/35302658/196c70b6-3bd9-4df3-8a3d-63a064ffc52e)
